### PR TITLE
Fix verification response parsing

### DIFF
--- a/site/verificacao.js
+++ b/site/verificacao.js
@@ -389,11 +389,12 @@ document.addEventListener("DOMContentLoaded", () => {
           }
         )
 
+        const raw = await response.text()
         let data = null
         try {
-          data = await response.json()
-        } catch {
-          console.error("Resposta inválida:", await response.text())
+          data = JSON.parse(raw)
+        } catch (err) {
+          console.error("Resposta inválida:", raw)
           showCustomAlert("Erro de conexão. Tente novamente.", "error")
           resetVerifyBtn()
           return


### PR DESCRIPTION
## Summary
- handle invalid JSON when verifying phone code

## Testing
- `npm test --prefix site` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841aba2a4c08329925601f09616f27b